### PR TITLE
remove deprecated reload function

### DIFF
--- a/toolbar/leo.shelf
+++ b/toolbar/leo.shelf
@@ -11,7 +11,6 @@
 
   <tool name="leo_random_ramp" label="LEO Random Ramp" icon="$LEO/misc/LEO_logo_v001.svg">
     <script scriptType="python"><![CDATA[import leo_random_ramp 
-reload(leo_random_ramp)
 leo_random_ramp.run()]]></script>
   </tool>
 </shelfDocument>


### PR DESCRIPTION
removed reload from the random ramp shelf tool because it no longer exists in python 3.x